### PR TITLE
Update translation badge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         name: Build the documentation
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   submodules: true
             - name: Install Sphinx

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ propagated to generated documents. You can also translate online at
 <https://hosted.weblate.org/projects/phpmyadmin/documentation/> and your changes
 will be merged to Git.
 
-.. image:: https://hosted.weblate.org/widgets/phpmyadmin/-/svg-badge.svg
+.. image:: https://hosted.weblate.org/widget/phpmyadmin/documentation/svg-badge.svg
     :alt: Translation status
     :target: https://hosted.weblate.org/engage/phpmyadmin/?utm_source=widget
 

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ will be merged to Git.
 
 .. image:: https://hosted.weblate.org/widget/phpmyadmin/documentation/svg-badge.svg
     :alt: Translation status
-    :target: https://hosted.weblate.org/engage/phpmyadmin/?utm_source=widget
+    :target: https://hosted.weblate.org/engage/phpmyadmin/
 
 .. image:: https://github.com/phpmyadmin/localized_docs/actions/workflows/build.yml/badge.svg?branch=master
     :alt: Build documentation


### PR DESCRIPTION
The translation badge was for phpMyAdmin and not for phpMyAdmin Documentation.

I also removed the tracking param since there's no longer on the weblate page

https://hosted.weblate.org/widgets/phpmyadmin/?component=64