### PR TITLE
Set persist-credentials to false

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
       steps:
         - uses: actions/checkout@v7
           with:
+              lfs: false
+              persist-credentials: false
               submodules: true
         - id: language-list
           name: Send languages to outputs
@@ -40,6 +42,8 @@ jobs:
         steps:
             - uses: actions/checkout@v7
               with:
+                  lfs: false
+                  persist-credentials: false
                   submodules: true
             - name: Install Sphinx-doc
               run: |


### PR DESCRIPTION
@williamdes I've got this check from Aikido when updating `actions/checkout` on device-detector:

```
GitHub Action actions/checkout persist Git credentials in workflow - low severity

actions/checkout v2 and above persist the default GITHUB_TOKEN in the repository's local git config when persist-credentials is not set to false, during the workflow run. Subsequent workflow steps or third-party actions can read this token from git configuration, increasing the risk of credential theft or misuse within the pipeline. In order to limit the attack surface when external actions are compromised, ensure persist-credentials is set to false.

Show fix

Remediation: Set persist-credentials: false on actions/checkout steps that do not need to push commits back to the repository. Only keep persist-credentials: true when the workflow explicitly performs authenticated git push operations.
```

I considered to also fix here.
